### PR TITLE
Adding Embedding Parameters to localconfig.py

### DIFF
--- a/timbre_conditioned_vae/tcvae/localconfig.py
+++ b/timbre_conditioned_vae/tcvae/localconfig.py
@@ -18,6 +18,7 @@ class LocalConfig:
     strides = 2
     use_lstm_in_encoder = True
     use_heuristics = True
+    use_embeddings = False
     hidden_dim = 256
     default_k = 3
     deep_decoder = False
@@ -35,6 +36,8 @@ class LocalConfig:
     starting_midi_pitch = 40
     num_pitches = 49
     num_velocities = 5
+    pitch_emb_size = 16
+    velocity_emb_size = 4
     max_num_harmonics = 98
     row_dim = 1024
     col_dim = 128


### PR DESCRIPTION
Adding 3 parameters to align with the changes to model.py: use_embeddings, pitch_emb_size, velocity_emb_size. These will be off by default but can be turned on simply by setting use_embeddings == True.