### PR TITLE
Adding Embedding layer options in model.py

### DIFF
--- a/timbre_conditioned_vae/tcvae/model.py
+++ b/timbre_conditioned_vae/tcvae/model.py
@@ -187,6 +187,12 @@ def reshape_z(block, z_input, conf: LocalConfig):
     current_z = tf.keras.layers.Reshape(target_shape=target_shape)(current_z)
     return current_z
 
+def embedding_layers(note_number, velocity, conf: LocalConfig):
+    pitch_emb = tf.keras.layers.Embedding(conf.num_pitches, conf.pitch_emb_size, input_length=1, name="pitch_emb")(note_number)
+    velocity_emb = tf.keras.layers.Embedding(conf.num_velocities, conf.velocity_emb_size, input_length=1, name="vel_emb")(velocity)
+    pitch_emb = tf.keras.layers.Flatten()(pitch_emb)
+    velocity_emb = tf.keras.layers.Flatten()(velocity_emb)
+    return pitch_emb, velocity_emb
 
 def create_decoder(conf: LocalConfig):
     if conf is None:


### PR DESCRIPTION
Adding function for creating embedding layers that returns pitch embedding (pitch_emb) and velocity embedding (velocity_emb) that takes as input the note_number and velocity input layers. These also take as parameters conf.use_embeddings (boolean), conf. pitch_emb_size (int), conf.velocity_emb_size (int) which I will also add to the LocalConfig page as variables.